### PR TITLE
all: do not use machine.TWI_FREQ_* constants

### DIFF
--- a/examples/adt7410/main.go
+++ b/examples/adt7410/main.go
@@ -15,7 +15,7 @@ var (
 
 func main() {
 
-	i2c.Configure(machine.I2CConfig{Frequency: machine.TWI_FREQ_400KHZ})
+	i2c.Configure(machine.I2CConfig{Frequency: 400e3})
 	sensor.Configure()
 
 	for {

--- a/examples/hd44780i2c/main.go
+++ b/examples/hd44780i2c/main.go
@@ -14,7 +14,7 @@ func main() {
 	// use 3.3V (and may be damaged by 5V).
 
 	machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 
 	lcd := hd44780i2c.New(machine.I2C0, 0x27) // some modules have address 0x3F

--- a/examples/mcp23017-multiple/main.go
+++ b/examples/mcp23017-multiple/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	err := machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 	if err != nil {
 		panic(err)

--- a/examples/mcp23017/main.go
+++ b/examples/mcp23017/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	err := machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 	if err != nil {
 		panic(err)

--- a/examples/ssd1306/i2c_128x32/main.go
+++ b/examples/ssd1306/i2c_128x32/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 
 	display := ssd1306.NewI2C(machine.I2C0)

--- a/examples/tmp102/main.go
+++ b/examples/tmp102/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 
 	thermo := tmp102.New(machine.I2C0)


### PR DESCRIPTION
### **User description**
These constants were always a bit weird:

  * they use an uncommon name (TWI instead of I2C)
  * they don't follow Go naming conventions (CamelCase)
  * the constants don't provide much value: their name is their value (100KHZ => 100e3).

Therefore, I propose we remove them and replace them with regular numeric constants.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>