### PR TITLE
Added support for Puya Semi P25Q16H flash

### DIFF
--- a/flash/devices.go
+++ b/flash/devices.go
@@ -36,6 +36,8 @@ var DefaultDeviceIdentifier = DeviceIdentifierFunc(func(id JedecID) Attrs {
 		return S25FL216K()
 	case 0x1F4501:
 		return AT25DF081A()
+	case 0x856015:
+		return P25Q16H()
 	case 0xC22015:
 		return MX25L1606()
 	case 0xC22016:
@@ -72,6 +74,24 @@ var DefaultDeviceIdentifier = DeviceIdentifierFunc(func(id JedecID) Attrs {
 		return Attrs{JedecID: id}
 	}
 })
+
+// Settings for Puya Semi P25Q16H 16MiB QSPI flash.
+// Datasheet: https://www.puyasemi.com/uploadfiles/2018/08/20180807152503253.pdf
+func P25Q16H() Attrs {
+	return Attrs{
+		TotalSize:           1 << 24, // 16 MiB
+		StartUp:             12 * time.Microsecond,
+		JedecID:             JedecID{0x85, 0x60, 0x15},
+		MaxClockSpeedMHz:    104,
+		QuadEnableBitMask:   0x02,
+		HasSectorProtection: false,
+		SupportsFastRead:    true,
+		SupportsQSPI:        true,
+		SupportsQSPIWrites:  true,
+		WriteStatusSplit:    false,
+		SingleStatusByte:    true,
+	}
+}
 
 // Settings for the Cypress (was Spansion) S25FL064L 8MiB SPI flash.
 // Datasheet: http://www.cypress.com/file/316661/download


### PR DESCRIPTION
### **User description**
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


___

### **Description**
- Added support for Puya Semi P25Q16H 16MiB QSPI flash in the devices file.
- Defined a new function `P25Q16H` with specific attributes for the flash.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devices.go</strong><dd><code>Added support for Puya Semi P25Q16H flash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flash/devices.go
['Added support for Puya Semi P25Q16H 16MiB QSPI flash', 'Defined function `P25Q16H` with specific attributes for the flash']


</details>


  </td>
  <td><a href="https://github.com/2lambda123/tinygo-org-drivers/pull/7/files#diff-307153de6b4fa6b96b30fa3cc7e14f14bd9a15ad9cbc90c3e9d05d31d7a58787">+20/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>